### PR TITLE
Added support for multiple attribute checks in same call and wildcard ouput/perf

### DIFF
--- a/check_json.pl
+++ b/check_json.pl
@@ -8,8 +8,8 @@ use Nagios::Plugin;
 use Data::Dumper;
 
 my $np = Nagios::Plugin->new(
-    usage => "Usage: %s -u|--url <URL> -a|--attribute <attribute> "
-    . "[ -c|--critical <threshold> ] [ -w|--warning <threshold> ] "
+    usage => "Usage: %s -u|--url <URL> -a|--attributes <attributes> "
+    . "[ -c|--critical <thresholds> ] [ -w|--warning <thresholds> ] "
     . "[ -p|--perfvars <fields> ] "
     . "[ -o|--outputvars <fields> ] "
     . "[ -t|--timeout <timeout> ] "
@@ -20,7 +20,7 @@ my $np = Nagios::Plugin->new(
     version => '0.4',
     blurb   => 'Nagios plugin to check JSON attributes via http(s)',
     extra   => "\nExample: \n"
-    . "check_json.pl --url http://192.168.5.10:9332/local_stats --attribute '{shares}->{dead}' "
+    . "check_json.pl --url http://192.168.5.10:9332/local_stats --attributes '{shares}->{dead}' "
     . "--warning :5 --critical :10 --perfvars '{shares}->{dead},{shares}->{live}' "
     . "--outputvars '{status_message}'",
     url     => 'https://github.com/c-kr/check_json',
@@ -37,8 +37,8 @@ $np->add_arg(
 );
 
 $np->add_arg(
-    spec => 'attribute|a=s',
-    help => '-a, --attribute {shares}->{dead}',
+    spec => 'attributes|a=s',
+    help => '-a, --attributes {shares}->{dead},{shares}->{uptime}',
     required => 1,
 );
 
@@ -63,13 +63,13 @@ $np->add_arg(
 
 $np->add_arg(
     spec => 'perfvars|p=s',
-    help => "-p, --perfvars eg. '{shares}->{dead},{shares}->{live}'\n   "
+    help => "-p, --perfvars eg. '* or {shares}->{dead},{shares}->{live}'\n   "
     . "CSV list of fields from JSON response to include in perfdata "
 );
 
 $np->add_arg(
     spec => 'outputvars|o=s',
-    help => "-o, --outputvars eg. '{status_message}'\n   "    
+    help => "-o, --outputvars eg. '* or {status_message}'\n   "    
     . "CSV list of fields output in status message, same syntax as perfvars"
 );
 
@@ -118,27 +118,47 @@ if ($response->is_success) {
 my $json_response = decode_json($response->content);
 if ($np->opts->verbose) { (print Dumper ($json_response))};
 
+my @attributes = split(',', $np->opts->attributes);
+my @warning = split(',', $np->opts->warning);
+my @critical = split(',', $np->opts->critical);
+my @divisor = $np->opts->divisor ? split(',',$np->opts->divisor) : () ;
+my %attributes = map { $attributes[$_] => { warning => $warning[$_] , critical => $critical[$_], divisor => ($divisor[$_] or 0) } } 0..$#attributes;
+
+my %check_value;
 my $check_value;
-my $check_value_str = '$check_value = $json_response->'.$np->opts->attribute;
+my $result = -1;
 
-if ($np->opts->verbose) { (print Dumper ($check_value_str))};
-eval $check_value_str;
+foreach my $attribute (sort keys %attributes){
+    my $check_value;
+    my $check_value_str = '$check_value = $json_response->'.$attribute;
+    
+    if ($np->opts->verbose) { (print Dumper ($check_value_str))};
+    eval $check_value_str;
 
-if (!defined $check_value) {
-    $np->nagios_exit(UNKNOWN, "No value received");
+    if (!defined $check_value) {
+        $np->nagios_exit(UNKNOWN, "No value received");
+    }
+
+    if ($attributes{$attribute}{'divisor'}) {
+        $check_value = $check_value/$attributes{$attribute}{'divisor'};
+    }
+
+    my $resultTmp = $np->check_threshold(
+        check => $check_value,
+        warning => $attributes{$attribute}{'warning'},
+        critical => $attributes{$attribute}{'critical'}
+    );
+    $result = $resultTmp if $result < $resultTmp;
+
+    $attributes{$attribute}{'check_value'}=$check_value;
 }
-
-if (defined $np->opts->divisor) {
-    $check_value = $check_value/$np->opts->divisor;
-}
-
-my $result = $np->check_threshold($check_value);
 
 my @statusmsg;
 
+
 # routine to add perfdata from JSON response based on a loop of keys given in perfvals (csv)
 if ($np->opts->perfvars) {
-    foreach my $key (split(',', $np->opts->perfvars)) {
+    foreach my $key ($np->opts->perfvars eq '*' ? map { "{$_}"} sort keys $json_response : split(',', $np->opts->perfvars)) {
         # use last element of key as label
         my $label = (split('->', $key))[-1];
         # make label ascii compatible
@@ -148,12 +168,12 @@ if ($np->opts->perfvars) {
         if ($np->opts->verbose) { print Dumper ("JSON key: ".$label.", JSON val: " . $perf_value) };
         if ( defined($perf_value) ) {
             # add threshold if attribute option matches key
-            if ($key eq $np->opts->attribute) {
-                push(@statusmsg, "$label: $check_value");
+            if ($attributes{$key}) {
+                push(@statusmsg, "$label: $attributes{$key}{'check_value'}");
                 $np->add_perfdata(
                     label => lc $label,
-                    value => $check_value,
-                    threshold => $np->threshold(),
+                    value => $attributes{$key}{'check_value'},
+                    threshold => $np->set_thresholds( warning => $attributes{$key}{'warning'}, critical => $attributes{$key}{'critical'}),
                 );
             } else {
                 push(@statusmsg, "$label: $perf_value");
@@ -168,14 +188,14 @@ if ($np->opts->perfvars) {
 
 # output some vars in message
 if ($np->opts->outputvars) {
-    foreach my $key (split(',', $np->opts->outputvars)) {
+    foreach my $key ($np->opts->outputvars eq '*' ? map { "{$_}"} sort keys $json_response : split(',', $np->opts->outputvars)) {
         # use last element of key as label
         my $label = (split('->', $key))[-1];
         # make label ascii compatible
         $label =~ s/[^a-zA-Z0-9_-]//g;
         my $perf_value;
         $perf_value = eval '$json_response->'.$key;
-	push(@statusmsg, "$label: $perf_value");
+	   push(@statusmsg, "$label: $perf_value");
     }
 }
 
@@ -183,4 +203,3 @@ $np->nagios_exit(
     return_code => $result,
     message     => join(', ', @statusmsg),
 );
-


### PR DESCRIPTION
I've made changes to allow multiple keys to affect the check result which is reduces the number of checks required when checking multiple values.

I've also aded the option to use wild card in output or perf.

ex: ./check_json.pl -u <URL> -a '{key1},{key2},...' -c <crit1>,<crit2>,... -w <warn1>,<warn2>,... -p '*'
