### PR TITLE
fix error if warning and/or critical not defined

### DIFF
--- a/check_json.pl
+++ b/check_json.pl
@@ -139,8 +139,14 @@ my $json_response = decode_json($response->content);
 if ($np->opts->verbose) { (print Dumper ($json_response))};
 
 my @attributes = split(',', $np->opts->attributes);
-my @warning = split(',', $np->opts->warning);
-my @critical = split(',', $np->opts->critical);
+my @warning;
+if ($np->opts->warning) {
+    @warning = split(',', $np->opts->warning);
+}
+my @critical;
+if ($np->opts->critical) {
+    @critical = split(',', $np->opts->critical);
+}
 my @divisor = $np->opts->divisor ? split(',',$np->opts->divisor) : () ;
 my %attributes = map { $attributes[$_] => { warning => $warning[$_] , critical => $critical[$_], divisor => ($divisor[$_] or 0) } } 0..$#attributes;
 


### PR DESCRIPTION
Since warning and critical are not required params, we should check to see if they are defined first before looping over them.  Otherwise, we get an error in the output.