### PR TITLE
fix output_value not referencing correct key

### DIFF
--- a/check_json.pl
+++ b/check_json.pl
@@ -245,10 +245,10 @@ if ($np->opts->outputvars) {
     foreach my $key ($np->opts->outputvars eq '*' ? map { "{$_}"} sort keys %$json_response : split(',', $np->opts->outputvars)) {
         # use last element of key as label
         my $label = (split('->', $key))[-1];
-        # make label ascii compatible
+        # make label ascii compatible i.e. remove the { and }
         $label =~ s/[^a-zA-Z0-9_-]//g;
         my $output_value;
-        $output_value = $json_response->{$key};
+        $output_value = $json_response->{$label};
         push(@statusmsg, "$label: $output_value");
     }
 }


### PR DESCRIPTION
This patch fixes the output_value var referencing, which would produce an error like 

```
Use of uninitialized value $output_​value in concatenation (.​) or string at 
/usr/lib/nagios/plugins/check_​json.​pl line 251.
```

The output_value var was attempting to reference a key like: 

`$json_response->{$key}`
where 
`$key = "{foo}"`

However, that would interpolate as:
`$json_repsonse->{"{foo}"}`
which obviously doesn't work.  

