### PR TITLE
Allow multi-level fields for perf/output vars

### DIFF
--- a/check_json.pl
+++ b/check_json.pl
@@ -218,7 +218,9 @@ if ($np->opts->perfvars) {
         # make label ascii compatible
         $label =~ s/[^a-zA-Z0-9_-]//g  ;
         my $perf_value;
-        $perf_value = $json_response->{$key};
+        my $perf_value_str = '$perf_value = $json_response->'.$key;
+        if ($np->opts->verbose) { (print Dumper ($perf_value_str))};
+        eval $perf_value_str;
         if ($np->opts->verbose) { print Dumper ("JSON key: ".$label.", JSON val: " . $perf_value) };
         if ( defined($perf_value) ) {
             # add threshold if attribute option matches key
@@ -248,7 +250,9 @@ if ($np->opts->outputvars) {
         # make label ascii compatible
         $label =~ s/[^a-zA-Z0-9_-]//g;
         my $output_value;
-        $output_value = $json_response->{$key};
+        my $output_value_str = '$output_value = $json_response->'.$key;
+        if ($np->opts->verbose) { (print Dumper ($output_value_str))};
+        eval $output_value_str;
         push(@statusmsg, "$label: $output_value");
     }
 }


### PR DESCRIPTION
Currently, specifying perf or output vars only works for top-level or simple fields within JSON. It doesn't work with more complicated node trees, e.g. "{main_node}[0]->{secondary_node}[4]->{final_node}".

This change fixes this issue by parsing the perf and output var JSON fields in the same way that the attribute JSON field is parsed.